### PR TITLE
Adding latitude range option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ points are computed. The step size is 1°/resolution, i.e. higher
 resolution values have smaller step sizes and more points in the
 polygon. The default value is 2.
 
+Leaflet.Terminator computes the terminator from longitudes -360° to +360°
+(a range of 720°), covering the Earth twice. To limit the terminator
+longitude range, the `longitudeRange` option is available.
+
+```js
+var sunlightOverlay = L.terminator({resolution: 5, longitudeRange:360});
+```
 
 You can pass the `time` option in the constructor or use the `setTime()`
 method to control the reference time and date for the terminator; the

--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ var Terminator = L.Polygon.extend({
 		opacity: 0.5,
 		fillColor: '#00',
 		fillOpacity: 0.5,
-		resolution: 2
+		resolution: 2,
+		longitudeRange: 720
 	},
 
 	initialize: function (options) {
@@ -118,17 +119,17 @@ var Terminator = L.Polygon.extend({
 		var sunEclPos = this._sunEclipticPosition(julianDay);
 		var eclObliq = this._eclipticObliquity(julianDay);
 		var sunEqPos = this._sunEquatorialPosition(sunEclPos.lambda, eclObliq);
-		for (var i = 0; i <= 720 * this.options.resolution; i++) {
-			var lng = -360 + i / this.options.resolution;
+		for (var i = 0; i <= this.options.longitudeRange * this.options.resolution; i++) {
+			var lng = -this.options.longitudeRange/2 + i / this.options.resolution;
 			var ha = this._hourAngle(lng, sunEqPos, gst);
 			latLng[i + 1] = [this._latitude(ha, sunEqPos), lng];
 		}
 		if (sunEqPos.delta < 0) {
-			latLng[0] = [90, -360];
-			latLng[latLng.length] = [90, 360];
+			latLng[0] = [90, -this.options.longitudeRange/2];
+			latLng[latLng.length] = [90, this.options.longitudeRange/2];
 		} else {
-			latLng[0] = [-90, -360];
-			latLng[latLng.length] = [-90, 360];
+			latLng[0] = [-90, -this.options.longitudeRange/2];
+			latLng[latLng.length] = [-90, this.options.longitudeRange/2];
 		}
 		return latLng;
 	}


### PR DESCRIPTION
Fixed javascript code and added documentation in README.md.

This change allows to limit the size of the terminator to accommodate maps that do not wrap over more than 360 degrees.